### PR TITLE
B1: Backend Entity/Repo    Epic: Add Announcements

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Announcements.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Announcements.java
@@ -1,0 +1,35 @@
+package edu.ucsb.cs156.happiercows.entities;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Entity;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import org.apache.tomcat.jni.Local;
+
+import javax.persistence.GeneratedValue;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "announcements")
+public class Announcements {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private long commonsId;
+
+  @Builder.Default
+  private LocalDateTime start = LocalDateTime.now();
+  @Builder.Default
+  private LocalDateTime end = null;
+  private String announcement;
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/repositories/AnnouncementsRepository.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/repositories/AnnouncementsRepository.java
@@ -1,0 +1,12 @@
+package edu.ucsb.cs156.happiercows.repositories;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import edu.ucsb.cs156.happiercows.entities.Announcements;
+
+
+@Repository
+public interface AnnouncementsRepository extends CrudRepository<Announcements, Long> {
+
+}


### PR DESCRIPTION
## Overview
Issue B1: Backend, Add Entity / Repository for announcements

- [x] There is an entity file for an Announcements table with field described below
- [x] There is an repository file for a Announcements table

Fields:
id, long autogenerated
commonsId, required, id of the associated commons
start (required, datetime to start showing the announcement, defaults to current datetime)
end (optional, datetime to stop showing the announcement)
announcement (String)

Closes #23
