### PR TITLE
AJ -- B2:Backend and Post

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
@@ -1,0 +1,84 @@
+package edu.ucsb.cs156.happiercows.controllers;
+
+import edu.ucsb.cs156.happiercows.entities.Announcements;
+import edu.ucsb.cs156.happiercows.repositories.AnnouncementsRepository;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+import java.time.LocalDateTime;
+
+@Tag(name = "Announcements")
+@RequestMapping("/api/announcements")
+@RestController
+public class AnnouncementsController extends ApiController{
+    @Autowired
+    AnnouncementsRepository announcementsRepository;
+
+    @Autowired
+    CommonsRepository commonsRepository;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @Operation(summary= "List all announcements")
+    @PreAuthorize("hasAnyRole('ROLE_USER', 'ROLE_ADMIN')")
+    @GetMapping("/all")
+    public Iterable<Announcements> allAnnouncements() {
+        Iterable<Announcements> announcements = announcementsRepository.findAll();
+        return announcements;
+    }
+
+    @Operation(summary= "Create a new announcement")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public ResponseEntity<?> postAnnouncements(
+            @Parameter(name="commonsId") @RequestParam long commonsId,
+            @Parameter(name = "start", description = "in iso format, e.g. YYYY-mm-ddTHH:MM:SSorg/wiki/ISO_8601") @RequestParam("start") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
+            @Parameter(name = "end", description = "in iso format, e.g. YYYY-mm-ddTHH:MM:SSorg/wiki/ISO_8601") @RequestParam(value = "end", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end,
+            @Parameter(name = "announcement") @RequestParam String announcement)
+            throws JsonProcessingException {
+
+        // For an explanation of @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        // See: https://www.baeldung.com/spring-date-parameters
+        if (end != null && end.isBefore(start)) {
+            return ResponseEntity.badRequest().body("End date must be after start date");
+        }
+        if (commonsRepository.findById(commonsId).isEmpty()) {
+            return ResponseEntity.badRequest().body("Invalid commondId");
+        }
+        Announcements newAnnouncement = Announcements.builder()
+                .commonsId(commonsId)
+                .start(start)
+                .end(end)
+                .announcement(announcement)
+                .build();
+
+        Announcements savedAnnouncement = announcementsRepository.save(newAnnouncement);
+        String body = mapper.writeValueAsString(savedAnnouncement);
+
+        return ResponseEntity.ok().body(body);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsControllerTests.java
@@ -1,0 +1,205 @@
+package edu.ucsb.cs156.happiercows.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import edu.ucsb.cs156.happiercows.ControllerTestCase;
+import edu.ucsb.cs156.happiercows.repositories.AnnouncementsRepository;
+import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
+import edu.ucsb.cs156.happiercows.entities.Announcements;
+import edu.ucsb.cs156.happiercows.entities.ChatMessage;
+import edu.ucsb.cs156.happiercows.entities.Commons;
+import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.entities.UserCommons;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@WebMvcTest(controllers = AnnouncementsController.class)
+@Import(AnnouncementsController.class)
+@AutoConfigureDataJpa
+public class AnnouncementsControllerTests extends ControllerTestCase {
+
+    @MockBean
+    AnnouncementsRepository announcementsRepository;
+
+    @MockBean
+    UserCommonsRepository userCommonsRepository;
+
+    @MockBean
+    CommonsRepository commonsRepository;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    //get
+
+
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void userInCommonsCanGetAnnouncements() throws Exception {
+        Announcements announcement = new Announcements();
+        announcement.setCommonsId(1L);
+        announcement.setStart(LocalDateTime.parse("2024-01-01T00:00:00"));
+        announcement.setEnd(LocalDateTime.parse("2024-01-01T00:00:00"));
+        announcement.setAnnouncement("Test announcement");
+
+        when(announcementsRepository.findAll()).thenReturn(Arrays.asList(announcement));
+
+        //act 
+        MvcResult response = mockMvc.perform(get("/api/announcements/all"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        verify(announcementsRepository, times(1)).findAll();
+
+        String responseString = response.getResponse().getContentAsString();
+        String expectedResponseString = mapper.writeValueAsString(Arrays.asList(announcement));
+        log.info("Got back from API: {}",responseString);
+        assertEquals(expectedResponseString, responseString);
+    }
+
+    //post 
+
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void adminCanPostAnnouncements() throws Exception {
+        Long commonsId = 1L;
+        LocalDateTime start = LocalDateTime.parse("2024-01-01T00:00:00");
+        LocalDateTime end = LocalDateTime.parse("2024-01-03T00:00:00");
+        String announcement = "Test announcement";
+
+
+        Announcements announcements = Announcements.builder()
+            .commonsId(commonsId)
+            .start(start)
+            .end(end)
+            .announcement(announcement)
+            .build();
+
+        when(announcementsRepository.save(announcements)).thenReturn(announcements);
+        when(commonsRepository.findById(commonsId)).thenReturn(Optional.of(new Commons()));
+
+
+        //act 
+        MvcResult response = mockMvc.perform(post("/api/announcements/post?commonsId={commonsId}&start={start}&end={end}&announcement={announcement}", commonsId, start, end, announcement).with(csrf()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // assert
+        verify(commonsRepository, times(1)).findById(commonsId);
+        verify(announcementsRepository, times(1)).save(any(Announcements.class));
+
+        String responseString = response.getResponse().getContentAsString();
+        String expectedResponseString = mapper.writeValueAsString(announcements);
+        log.info("Got back from API: {}",responseString);
+        assertEquals(expectedResponseString, responseString);
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void adminCanPostAnnouncementsWithNoEnd() throws Exception {
+        Long commonsId = 1L;
+        LocalDateTime start = LocalDateTime.parse("2024-01-01T00:00:00");
+        LocalDateTime end = null;
+        String announcement = "Test announcement";
+
+
+        Announcements announcements = new Announcements();
+        announcements.setCommonsId(commonsId);
+        announcements.setStart(start);
+        announcements.setEnd(end);
+        announcements.setAnnouncement(announcement);
+
+        when(announcementsRepository.save(any(Announcements.class))).thenReturn(announcements);
+        when(commonsRepository.findById(commonsId)).thenReturn(Optional.of(new Commons()));
+
+
+        //act 
+        MvcResult response = mockMvc.perform(post("/api/announcements/post?commonsId={commonsId}&start={start}&end={end}&announcement={announcement}", commonsId, start, end, announcement).with(csrf()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // assert
+        verify(commonsRepository, times(1)).findById(commonsId);
+        verify(announcementsRepository, times(1)).save(any(Announcements.class));
+
+        String responseString = response.getResponse().getContentAsString();
+        String expectedResponseString = mapper.writeValueAsString(announcements);
+        log.info("Got back from API: {}",responseString);
+        assertEquals(expectedResponseString, responseString);
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void adminCannotPostEndDateBeforeStartDate() throws Exception {
+        Long commonsId = 1L;
+        LocalDateTime start = LocalDateTime.parse("2024-01-03T00:00:00");
+        LocalDateTime end = LocalDateTime.parse("2024-01-01T00:00:00");
+        String announcement = "Test announcement";
+
+        //act 
+        MvcResult response = mockMvc.perform(post("/api/announcements/post?commonsId={commonsId}&start={start}&end={end}&announcement={announcement}", commonsId, start, end, announcement).with(csrf()))
+                .andExpect(status().isBadRequest())
+                .andReturn();
+
+        String responseString = response.getResponse().getContentAsString();
+        String expectedResponseString = "End date must be after start date";
+        log.info("Got back from API: {}",responseString);
+        assertEquals(expectedResponseString, responseString);
+    }
+
+    @WithMockUser(roles = {"ADMIN"})
+    @Test
+    public void adminCannotPostWithoutCommons() throws Exception {
+        Long commonsId = 1L;
+        LocalDateTime start = LocalDateTime.parse("2024-01-01T00:00:00");
+        LocalDateTime end = LocalDateTime.parse("2024-01-03T00:00:00");
+        String announcement = "Test announcement";
+
+        //act 
+        MvcResult response = mockMvc.perform(post("/api/announcements/post?commonsId={commonsId}&start={start}&end={end}&announcement={announcement}", commonsId, start, end, announcement).with(csrf()))
+                .andExpect(status().isBadRequest())
+                .andReturn();
+
+        String responseString = response.getResponse().getContentAsString();
+        String expectedResponseString = "Invalid commondId";
+        log.info("Got back from API: {}",responseString);
+        assertEquals(expectedResponseString, responseString);
+    }
+
+}


### PR DESCRIPTION
## Overview
Issue B2: Backend Controller for CRUD operations for announcements

- [x]  There is a POST endpoint to post a new announcement
- [x]  The POST endpoint to create new announcements rejects POST values with invalid data (e.g. a commonsId for a commons that doesn't exist, announcements with empty text, end date that is before start date, start date blank)
- [x]  The POST endpoint allows end date to be blank, in which case it is stored as NULL in the database

## Future Possibilities (Optional)
- This is part of B2: Backend Epic (Backend Controller for CRUD operations for announcements).

## Tests
- [ ] Backend Unit tests (`mvn test`) pass
- [ ] Backend Test coverage (`mvn test jacoco:report`) 100%
- [ ] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [ ] Frontend Unit tests (`npm test`) pass
- [ ] Frontend Test coverage (`npm run coverage`) 100%
- [ ] Frontend Mutation tests (`npx stryker run`) 100% 
- [ ] Frontend Linting (`npx eslint --fix src`) 
